### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A MCP server for macOS that provides advanced system monitoring and file search 
 
 <img src="https://github.com/user-attachments/assets/45d755c8-a280-4d83-bc11-dd97eef9c662" width="400" alt="MCP Server Screenshot">
 
+<a href="https://glama.ai/mcp/servers/@tornikegomareli/macos-tools-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@tornikegomareli/macos-tools-mcp-server/badge" alt="macOS Tools Server MCP server" />
+</a>
+
 [![smithery badge](https://smithery.ai/badge/@tornikegomareli/macos-tools-mcp-server)](https://smithery.ai/server/@tornikegomareli/macos-tools-mcp-server)
 
 


### PR DESCRIPTION
This PR adds a badge for the [macOS Tools MCP Server](https://glama.ai/mcp/servers/@tornikegomareli/macos-tools-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@tornikegomareli/macos-tools-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@tornikegomareli/macos-tools-mcp-server/badge" alt="macOS Tools Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.